### PR TITLE
Stop the quickfix window

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,14 @@ function! CakePHPTestCallback(args)
 endfunction
 ```
 
+### Disable the Quickfix window
+
+You can stop the quickfix windows with:
+
+```vim
+let g:phpunit_quickfix=0
+```
+
 ### License
 
 This plugin is released under the [MIT License][3].

--- a/plugin/vim-phpunitqf.vim
+++ b/plugin/vim-phpunitqf.vim
@@ -14,7 +14,7 @@
 " to load it automatically, or load it manually with :so sauce.vim.
 "
 " License: MIT
-"                
+"
 " }}}
 " ------------------------------------------------------------------------------
 
@@ -59,6 +59,11 @@ if !exists("g:phpunit_debug")
     let g:phpunit_debug=0
 endif
 
+" Handle the quickfix feature
+if !exists("g:phpunit_quickfix")
+    let g:phpunit_quickfix=1
+endif
+
 if !exists("g:phpunit_callback")
     let g:phpunit_callback = ""
 endif
@@ -75,7 +80,9 @@ function! s:RunPHPUnitTests(arg)
     " Truncate current log file
     call system("> ".g:phpunit_tmpfile)
     exe "!".g:phpunit_cmd." ".g:phpunit_args." ".s:args." ".g:phpunit_args_append." 2>&1 | tee ".g:phpunit_tmpfile
-    python parse_test_output()
+    if g:phpunit_quickfix==1
+        python parse_test_output()
+    endif
 endfunction
 
 " Open the test output


### PR DESCRIPTION
The quickfix window feature is very useful, but, when i am working on Symfony apps or ZF app typically it shows to me errors in my dependencies like: doctrine or symfony core components and the focus is changed to the qf and i have to change the buffer with CTRL+W k that is annoying because i am focused elsewhere. I see the tests output in my shell and i can use the TestOutput feature in order to get back the error stack that i need. So, I have added a variable that i can put in my configuration in order to disable the quickfix window. 

```
let g:phpunit_quickfix=0
```

It is a very simple fix i don't know if you can interested in...
